### PR TITLE
Remove broken Google+ link and references

### DIFF
--- a/auth-oauth/authentication.php
+++ b/auth-oauth/authentication.php
@@ -9,7 +9,7 @@ class OauthAuthPlugin extends Plugin {
     function bootstrap() {
         $config = $this->getConfig();
 
-        # ----- Google Plus ---------------------
+        # ----- Google Sign-In ---------------------
         $google = $config->get('g-enabled');
         if (in_array($google, array('all', 'staff'))) {
             require_once('google.php');

--- a/auth-oauth/config.php
+++ b/auth-oauth/config.php
@@ -29,7 +29,7 @@ class OauthPluginConfig extends PluginConfig {
         ));
         return array(
             'google' => new SectionBreakField(array(
-                'label' => $__('Google+ Authentication'),
+                'label' => $__('Google Sign-In'),
             )),
             'g-client-id' => new TextboxField(array(
                 'label' => $__('Client ID'),

--- a/auth-oauth/google.php
+++ b/auth-oauth/google.php
@@ -43,10 +43,10 @@ class GoogleAuth {
 
 class GoogleStaffAuthBackend extends ExternalStaffAuthenticationBackend {
     static $id = "google";
-    static $name = "Google Plus";
+    static $name = "Google";
 
-    static $sign_in_image_url = "https://developers.google.com/+/images/branding/sign-in-buttons/White-signin_Long_base_44dp.png";
-    static $service_name = "Google+";
+    static $sign_in_image_url = false;
+    static $service_name = "Google";
 
     var $config;
 
@@ -99,10 +99,10 @@ class GoogleStaffAuthBackend extends ExternalStaffAuthenticationBackend {
 
 class GoogleClientAuthBackend extends ExternalUserAuthenticationBackend {
     static $id = "google.client";
-    static $name = "Google Plus";
+    static $name = "Google";
 
-    static $sign_in_image_url = "https://developers.google.com/+/images/branding/sign-in-buttons/Red-signin_Long_base_44dp.png";
-    static $service_name = "Google+";
+    static $sign_in_image_url = false;
+    static $service_name = "Google";
 
     function __construct($config) {
         $this->config = $config;

--- a/doc/auth-oauth.md
+++ b/doc/auth-oauth.md
@@ -1,25 +1,25 @@
 This OAuth plugin provides SSO sign in from many popular external sources
-including Google+, GitHub, Facebook, Windows Azure, and many more.
+including Google, GitHub, Facebook, Windows Azure, and many more.
 
-**At the current time, only Google+ authentication is implemented.**
+**At the current time, only Google authentication is implemented.**
 
-Google+ Authentication
-----------------------
-To register for Google+ authentication,
+Google Authentication
+---------------------
+To register for Google authentication,
 
 * Visit the Google Cloud Console (https://console.developers.google.com/)
 * Sign in to Google via a relevant account
 * Create a project (name it whatever -- osTicket Help Desk)
-* Manage the project, navigate to APIs and Auth / Credentials and create an
+* Manage the project, navigate to APIs and Services / Credentials and create an
   OAuth Client ID
 * Register the key with the URL of your helpdesk plus `api/auth/ext`
   (`http://support.mycompany.com/api/auth/ext`). This is called the *Redirect
   URI*
-* Navigate to APIs & Auth / Consent Screen and fill in the relevant information
-* Navigate to APIs & Auth / APIs and add / enable the *Google+ API*
+* Navigate to APIs & Services / OAuth Consent Screen and fill in the relevant
+  information
 * Install the plugin in osTicket **1.9**
-* Configure the plugin with your Google+ Client ID and Secret
+* Configure the plugin with your Client ID and Secret
 * Configure the plugin to authenticate agents (staff), users or both
 * Enable the OAuth plugin
-* Log out and back in with Google+
+* Log out and back in with Google
 * Enjoy!


### PR DESCRIPTION
This is a partial solution to the problem described in #1. It removes the broken link, and uses the default osTicket button for external authentication.

![login_screen](https://user-images.githubusercontent.com/2822585/91324674-9a806980-e7c2-11ea-92f4-b9ecc4d20bcf.png)

Full solution would be making the sign-in button compliant with Google [Sign-In Branding Guidelines](https://developers.google.com/identity/branding-guidelines), but I didn't find a quick way to do that.